### PR TITLE
feat: Add Biome for Formatting and Linting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"test": "vitest",
 		"test:run": "vitest run",
 		"format": "biome format --write .",
-		"lint": "biome lint --apply-unsafe .",
-		"check": "biome check --apply-unsafe ."
+		"lint": "biome lint --write --unsafe .",
+		"check": "biome check --write --unsafe ."
 	},
 	"dependencies": {
 		"hono": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "hono": "^4.7.5"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.4",
     "@cloudflare/vite-plugin": "^0.1.15",
     "@cloudflare/workers-types": "^4.20250214.0",
     "@edge-runtime/vm": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,28 @@
 {
-  "name": "notes-api",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "preview": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "test": "vitest",
-    "test:run": "vitest run"
-  },
-  "dependencies": {
-    "hono": "^4.7.5"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "1.9.4",
-    "@cloudflare/vite-plugin": "^0.1.15",
-    "@cloudflare/workers-types": "^4.20250214.0",
-    "@edge-runtime/vm": "^5.0.0",
-    "@types/node": "^22.14.0",
-    "vite": "^6.1.1",
-    "vite-plugin-ssr-hot-reload": "^0.4.1",
-    "vitest": "^3.1.1",
-    "wrangler": "^4.4.0"
-  }
+	"name": "notes-api",
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"preview": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"format": "biome format --write .",
+		"lint": "biome lint --apply-unsafe .",
+		"check": "biome check --apply-unsafe ."
+	},
+	"dependencies": {
+		"hono": "^4.7.5"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "1.9.4",
+		"@cloudflare/vite-plugin": "^0.1.15",
+		"@cloudflare/workers-types": "^4.20250214.0",
+		"@edge-runtime/vm": "^5.0.0",
+		"@types/node": "^22.14.0",
+		"vite": "^6.1.1",
+		"vite-plugin-ssr-hot-reload": "^0.4.1",
+		"vitest": "^3.1.1",
+		"wrangler": "^4.4.0"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^4.7.5
         version: 4.7.5
     devDependencies:
+      '@biomejs/biome':
+        specifier: 1.9.4
+        version: 1.9.4
       '@cloudflare/vite-plugin':
         specifier: ^0.1.15
         version: 0.1.20(vite@6.2.4(@types/node@22.14.0))(workerd@1.20250321.0)(wrangler@4.7.0(@cloudflare/workers-types@4.20250402.0))
@@ -38,6 +41,59 @@ importers:
         version: 4.7.0(@cloudflare/workers-types@4.20250402.0)
 
 packages:
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
@@ -1094,6 +1150,41 @@ packages:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
 snapshots:
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
 
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:

--- a/public/static/style.css
+++ b/public/static/style.css
@@ -1,3 +1,3 @@
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+	font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,12 @@
-import { Hono } from 'hono'
-import { renderer } from './renderer'
+import { Hono } from "hono";
+import { renderer } from "./renderer";
 
-const app = new Hono()
+const app = new Hono();
 
-app.use(renderer)
+app.use(renderer);
 
-app.get('/', (c) => {
-  return c.render(<h1>Hello!</h1>)
-})
+app.get("/", (c) => {
+	return c.render(<h1>Hello!</h1>);
+});
 
-export default app
+export default app;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,12 +1,12 @@
-import { jsxRenderer } from 'hono/jsx-renderer'
+import { jsxRenderer } from "hono/jsx-renderer";
 
 export const renderer = jsxRenderer(({ children }) => {
-  return (
-    <html>
-      <head>
-        <link href="/static/style.css" rel="stylesheet" />
-      </head>
-      <body>{children}</body>
-    </html>
-  )
-})
+	return (
+		<html lang="en">
+			<head>
+				<link href="/static/style.css" rel="stylesheet" />
+			</head>
+			<body>{children}</body>
+		</html>
+	);
+});

--- a/src/tests/example.test.ts
+++ b/src/tests/example.test.ts
@@ -3,12 +3,12 @@
 // Since we enabled 'globals: true', we don't need to import these:
 // import { describe, it, expect } from 'vitest'
 
-describe('Example Suite', () => {
-    it('should pass a basic truthiness test', () => {
-        expect(true).toBe(true);
-    });
+describe("Example Suite", () => {
+	it("should pass a basic truthiness test", () => {
+		expect(true).toBe(true);
+	});
 
-    it('should perform addition correctly', () => {
-        expect(1 + 1).toBe(2);
-    });
-}); 
+	it("should perform addition correctly", () => {
+		expect(1 + 1).toBe(2);
+	});
+});

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,18 +1,18 @@
 // src/tests/index.test.ts
 
-import app from '../index'; // Adjust path if your app export is elsewhere
+import app from "../index"; // Adjust path if your app export is elsewhere
 
-describe('Hono App Tests', () => {
-    it('should return Hello! for the root route GET /', async () => {
-        const res = await app.request('/');
-        const text = await res.text();
+describe("Hono App Tests", () => {
+	it("should return Hello! for the root route GET /", async () => {
+		const res = await app.request("/");
+		const text = await res.text();
 
-        expect(res.status).toBe(200);
-        expect(text).toContain('<h1>Hello!</h1>');
-    });
+		expect(res.status).toBe(200);
+		expect(text).toContain("<h1>Hello!</h1>");
+	});
 
-    it('should return 404 for non-existent route', async () => {
-        const res = await app.request('/non-existent-path');
-        expect(res.status).toBe(404);
-    });
-}); 
+	it("should return 404 for non-existent route", async () => {
+		const res = await app.request("/non-existent-path");
+		expect(res.status).toBe(404);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "skipLibCheck": true,
-    "lib": ["ESNext"],
-    "types": [
-      "@cloudflare/workers-types/2023-07-01",
-      "vite/client",
-      "vitest/globals"
-    ],
-    "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx"
-  }
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"lib": ["ESNext"],
+		"types": [
+			"@cloudflare/workers-types/2023-07-01",
+			"vite/client",
+			"vitest/globals"
+		],
+		"jsx": "react-jsx",
+		"jsxImportSource": "hono/jsx"
+	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,16 @@
 /// <reference types="vitest" />
-import { cloudflare } from '@cloudflare/vite-plugin'
-import { defineConfig } from 'vite'
-import ssrHotReload from 'vite-plugin-ssr-hot-reload'
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+import ssrHotReload from "vite-plugin-ssr-hot-reload";
 
 export default defineConfig({
-  plugins: [
-    ssrHotReload(),
-    // Conditionally add cloudflare plugin only when not running tests
-    !process.env.VITEST ? cloudflare() : null,
-  ],
-  test: {
-    globals: true,
-    environment: 'edge-runtime',
-  },
-})
+	plugins: [
+		ssrHotReload(),
+		// Conditionally add cloudflare plugin only when not running tests
+		!process.env.VITEST ? cloudflare() : null,
+	],
+	test: {
+		globals: true,
+		environment: "edge-runtime",
+	},
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,34 +1,34 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "notes-api",
-  "compatibility_date": "2024-04-01",
-  "main": "./src/index.tsx",
-  "assets": {
-    "directory": "./public"
-  }
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "notes-api",
+	"compatibility_date": "2024-04-01",
+	"main": "./src/index.tsx",
+	"assets": {
+		"directory": "./public"
+	}
+	// "vars": {
+	//   "MY_VAR": "my-variable"
+	// },
+	// "kv_namespaces": [
+	//   {
+	//     "binding": "MY_KV_NAMESPACE",
+	//     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	//   }
+	// ],
+	// "r2_buckets": [
+	//   {
+	//     "binding": "MY_BUCKET",
+	//     "bucket_name": "my-bucket"
+	//   }
+	// ],
+	// "d1_databases": [
+	//   {
+	//     "binding": "MY_DB",
+	//     "database_name": "my-database",
+	//     "database_id": ""
+	//   }
+	// ],
+	// "ai": {
+	//   "binding": "AI"
+	// }
 }


### PR DESCRIPTION
## Description

Integrates BiomeJS into the project for code formatting and linting, replacing the need for separate tools like Prettier and potentially ESLint.

Includes initial configuration and application of rules across the codebase.

## Changes Made

- Added `@biomejs/biome` dev dependency.
- Created `biome.json` configuration file with recommended defaults.
- Added `format`, `lint`, and `check` scripts to `package.json`.
- Applied initial formatting and lint fixes across the project.

## Testing

- Verified Biome commands run correctly via npm scripts.
- Reviewed code changes applied by Biome.
- Ensured existing project tests (`pnpm test:run`) pass after Biome integration and code modification.

## Next Steps (Optional)

- Configure CI to run Biome checks.
- Set up editor integration for real-time feedback.
- Customize Biome rules further if needed. 