### PR TITLE
feat: Implement Notes CRUD API

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,143 @@
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { renderer } from "./renderer";
 
+// --- Data Structure and Storage (In-Memory) ---
+export type Note = {
+	id: string;
+	title: string;
+	content: string;
+	createdAt: string;
+	updatedAt: string;
+};
+
+// WARNING: In-memory storage. Data is lost on restart/redeploy.
+// Replace with KV, D1, etc., for persistence.
+let notes: Note[] = [];
+let nextId = 1; // Simple ID generator
+
+// --- Hono App Setup ---
 const app = new Hono();
 
-app.use(renderer);
-
+// Root route still serves HTML via renderer
+app.use("/", renderer);
 app.get("/", (c) => {
-	return c.render(<h1>Hello!</h1>);
+	return c.render(<h1>Notes App API is Running!</h1>);
+});
+
+// --- API Routes (/api/notes) ---
+const api = new Hono().basePath("/api");
+
+// GET /api/notes - Get all notes
+api.get("/notes", (c) => {
+	return c.json(notes);
+});
+
+// POST /api/notes - Create a new note
+api.post("/notes", async (c) => {
+	try {
+		const { title, content } = await c.req.json<{
+			title: string;
+			content: string;
+		}>();
+		if (!title || !content) {
+			throw new HTTPException(400, {
+				message: "Title and content are required",
+			});
+		}
+		const now = new Date().toISOString();
+		const newNote: Note = {
+			id: (nextId++).toString(),
+			title,
+			content,
+			createdAt: now,
+			updatedAt: now,
+		};
+		notes.push(newNote);
+		return c.json(newNote, 201); // Respond with created note and status 201
+	} catch (error) {
+		if (error instanceof HTTPException) throw error;
+		// Handle JSON parsing errors or other unexpected issues
+		console.error("Error creating note:", error);
+		throw new HTTPException(400, { message: "Invalid request body" });
+	}
+});
+
+// GET /api/notes/:id - Get a single note by ID
+api.get("/notes/:id", (c) => {
+	const id = c.req.param("id");
+	const note = notes.find((n) => n.id === id);
+	if (!note) {
+		throw new HTTPException(404, { message: "Note not found" });
+	}
+	return c.json(note);
+});
+
+// PUT /api/notes/:id - Update a note by ID
+api.put("/notes/:id", async (c) => {
+	const id = c.req.param("id");
+	const noteIndex = notes.findIndex((n) => n.id === id);
+	if (noteIndex === -1) {
+		throw new HTTPException(404, { message: "Note not found" });
+	}
+
+	try {
+		const { title, content } = await c.req.json<{
+			title: string;
+			content: string;
+		}>();
+		if (!title || !content) {
+			throw new HTTPException(400, {
+				message: "Title and content are required",
+			});
+		}
+		const now = new Date().toISOString();
+		const updatedNote = {
+			...notes[noteIndex],
+			title,
+			content,
+			updatedAt: now,
+		};
+		notes[noteIndex] = updatedNote;
+		return c.json(updatedNote);
+	} catch (error) {
+		if (error instanceof HTTPException) throw error;
+		console.error(`Error updating note ${id}:`, error);
+		throw new HTTPException(400, { message: "Invalid request body" });
+	}
+});
+
+// DELETE /api/notes/:id - Delete a note by ID
+api.delete("/notes/:id", (c) => {
+	const id = c.req.param("id");
+	const initialLength = notes.length;
+	notes = notes.filter((n) => n.id !== id);
+	if (notes.length === initialLength) {
+		throw new HTTPException(404, { message: "Note not found" });
+	}
+	// Use 200 with message or 204 No Content
+	// return c.json({ message: "Note deleted successfully" });
+	return new Response(null, { status: 204 }); // Standard practice for DELETE success
+});
+
+// Register API routes with the main app
+app.route("/", api);
+
+// --- Error Handling ---
+app.onError((err, c) => {
+	console.error(`${err}`);
+	if (err instanceof HTTPException) {
+		// Use HTTPException status and message
+		return err.getResponse();
+	}
+	// Default internal server error
+	return c.json({ error: "Internal Server Error", message: err.message }, 500);
 });
 
 export default app;
+// Export notes array and a reset function ONLY for testing purposes
+export { notes as testOnlyNotes, resetNotes as testOnlyResetNotes };
+function resetNotes() {
+	notes = [];
+	nextId = 1;
+}

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,18 +1,248 @@
 // src/tests/index.test.ts
+import app, { type Note, testOnlyNotes, testOnlyResetNotes } from "../index"; // Import app, Note type, and test helpers
 
-import app from "../index"; // Adjust path if your app export is elsewhere
+// Helper function to make testing easier
+const makeRequest = (path: string, options?: RequestInit) => {
+	return app.request(path, options);
+};
 
-describe("Hono App Tests", () => {
-	it("should return Hello! for the root route GET /", async () => {
-		const res = await app.request("/");
-		const text = await res.text();
-
-		expect(res.status).toBe(200);
-		expect(text).toContain("<h1>Hello!</h1>");
+describe("Notes CRUD API Tests", () => {
+	// Reset notes before each test to ensure isolation
+	beforeEach(() => {
+		testOnlyResetNotes();
 	});
 
-	it("should return 404 for non-existent route", async () => {
-		const res = await app.request("/non-existent-path");
+	// --- Test Root Route ---
+	it("GET / should return HTML", async () => {
+		const res = await makeRequest("/");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toContain("text/html");
+		expect(await res.text()).toContain("<h1>Notes App API is Running!</h1>");
+	});
+
+	// --- Test POST /api/notes (Create) ---
+	describe("POST /api/notes", () => {
+		it("should create a new note successfully", async () => {
+			const noteData = { title: "Test Note", content: "Test Content" };
+			const res = await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(noteData),
+			});
+
+			expect(res.status).toBe(201);
+			const createdNote = await res.json<Note>();
+			expect(createdNote).toMatchObject(noteData); // Check if title/content match
+			expect(createdNote).toHaveProperty("id");
+			expect(createdNote).toHaveProperty("createdAt");
+			expect(createdNote).toHaveProperty("updatedAt");
+
+			// Verify it's actually stored (using exported test helper)
+			expect(testOnlyNotes).toHaveLength(1);
+			expect(testOnlyNotes[0]).toEqual(createdNote);
+		});
+
+		it("should return 400 if title or content is missing", async () => {
+			const badData = [
+				{ title: "Only Title" },
+				{ content: "Only Content" },
+				{},
+			];
+			for (const data of badData) {
+				const res = await makeRequest("/api/notes", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(data),
+				});
+				expect(res.status).toBe(400);
+				const errorText = await res.text();
+				expect(errorText).toBe("Title and content are required");
+			}
+			expect(testOnlyNotes).toHaveLength(0); // Ensure nothing was added
+		});
+
+		it("should return 400 for invalid JSON body", async () => {
+			const res = await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: "{invalid json",
+			});
+			expect(res.status).toBe(400);
+			const errorText = await res.text();
+			expect(errorText).toBe("Invalid request body");
+		});
+	});
+
+	// --- Test GET /api/notes (Read All) ---
+	describe("GET /api/notes", () => {
+		it("should return an empty array when no notes exist", async () => {
+			const res = await makeRequest("/api/notes");
+			expect(res.status).toBe(200);
+			expect(await res.json<Note[]>()).toEqual([]);
+		});
+
+		it("should return all existing notes", async () => {
+			// Add some notes first
+			await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "Note 1", content: "Content 1" }),
+			});
+			await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "Note 2", content: "Content 2" }),
+			});
+
+			const res = await makeRequest("/api/notes");
+			expect(res.status).toBe(200);
+			const notes = await res.json<Note[]>();
+			expect(notes).toHaveLength(2);
+			expect(notes[0].title).toBe("Note 1");
+			expect(notes[1].title).toBe("Note 2");
+		});
+	});
+
+	// --- Test GET /api/notes/:id (Read One) ---
+	describe("GET /api/notes/:id", () => {
+		it("should return a single note if found", async () => {
+			const postRes = await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "Find Me", content: "Here I am" }),
+			});
+			const { id } = await postRes.json<Note>();
+
+			const res = await makeRequest(`/api/notes/${id}`);
+			expect(res.status).toBe(200);
+			const note = await res.json<Note>();
+			expect(note.id).toBe(id);
+			expect(note.title).toBe("Find Me");
+		});
+
+		it("should return 404 if note not found", async () => {
+			const res = await makeRequest("/api/notes/999"); // Non-existent ID
+			expect(res.status).toBe(404);
+			const errorText = await res.text();
+			expect(errorText).toBe("Note not found");
+		});
+	});
+
+	// --- Test PUT /api/notes/:id (Update) ---
+	describe("PUT /api/notes/:id", () => {
+		it("should update an existing note", async () => {
+			const postRes = await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					title: "Original Title",
+					content: "Original Content",
+				}),
+			});
+			const { id, createdAt } = await postRes.json<Note>();
+
+			const updatedData = {
+				title: "Updated Title",
+				content: "Updated Content",
+			};
+			const putRes = await makeRequest(`/api/notes/${id}`, {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(updatedData),
+			});
+
+			expect(putRes.status).toBe(200);
+			const updatedNote = await putRes.json<Note>();
+			expect(updatedNote.id).toBe(id);
+			expect(updatedNote.title).toBe("Updated Title");
+			expect(updatedNote.content).toBe("Updated Content");
+			expect(updatedNote.createdAt).toBe(createdAt); // createdAt should not change
+			expect(updatedNote.updatedAt >= createdAt).toBe(true);
+
+			// Verify in storage
+			const storedNote = testOnlyNotes.find((n) => n.id === id);
+			expect(storedNote).toBeDefined();
+			expect(storedNote).toEqual(updatedNote);
+		});
+
+		it("should return 404 if note to update is not found", async () => {
+			const res = await makeRequest("/api/notes/999", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					title: "Update NonExistent",
+					content: "Content",
+				}),
+			});
+			expect(res.status).toBe(404);
+		});
+
+		it("should return 400 if title or content is missing on update", async () => {
+			const postRes = await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "To Update", content: "..." }),
+			});
+			const { id } = await postRes.json<Note>();
+
+			const badData = [
+				{ title: "Only Title" },
+				{ content: "Only Content" },
+				{},
+			];
+			for (const data of badData) {
+				const res = await makeRequest(`/api/notes/${id}`, {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(data),
+				});
+				expect(res.status).toBe(400);
+				const errorText = await res.text();
+				expect(errorText).toBe("Title and content are required");
+			}
+		});
+	});
+
+	// --- Test DELETE /api/notes/:id (Delete) ---
+	describe("DELETE /api/notes/:id", () => {
+		it("should delete an existing note and return 204", async () => {
+			const postRes = await makeRequest("/api/notes", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "To Delete", content: "Bye" }),
+			});
+			const { id } = await postRes.json<Note>();
+			expect(testOnlyNotes).toHaveLength(1); // Verify it exists
+
+			const deleteRes = await makeRequest(`/api/notes/${id}`, {
+				method: "DELETE",
+			});
+			expect(deleteRes.status).toBe(204); // No Content
+			expect(await deleteRes.text()).toBe(""); // No body for 204
+
+			// Verify it's removed from storage
+			expect(testOnlyNotes).toHaveLength(0);
+
+			// Verify GET returns 404 now
+			const getRes = await makeRequest(`/api/notes/${id}`);
+			expect(getRes.status).toBe(404);
+		});
+
+		it("should return 404 if note to delete is not found", async () => {
+			const res = await makeRequest("/api/notes/999", { method: "DELETE" });
+			expect(res.status).toBe(404);
+			const errorText = await res.text();
+			expect(errorText).toBe("Note not found");
+		});
+	});
+
+	// --- Test Non-existent API Route ---
+	it("should return 404 for non-existent API route", async () => {
+		const res = await makeRequest("/api/non-existent-path");
 		expect(res.status).toBe(404);
+		// Hono's default 404 might not be JSON, check based on behavior or add specific handling
+		// For now, just check status. If you added a global error handler returning JSON:
+		// const error = await res.json();
+		// expect(error.message).toContain("Not Found");
 	});
 });


### PR DESCRIPTION
## Description

Implements a basic in-memory CRUD API for notes under `/api/notes`.

This allows creating, reading, updating, and deleting notes.

**Note:** Uses non-persistent in-memory storage.

## Changes Made

- Added `Note` type definition.
- Implemented in-memory array `notes` and ID generator.
- Added Hono routes for:
  - `POST /api/notes` (Create)
  - `GET /api/notes` (Read All)
  - `GET /api/notes/:id` (Read One)
  - `PUT /api/notes/:id` (Update)
  - `DELETE /api/notes/:id` (Delete)
- Added basic input validation and error handling (400, 404).
- Added comprehensive Vitest tests for all CRUD operations and edge cases.
- Exported `notes` array and reset function for testing purposes only.

## Testing

- Ran `pnpm test:run` - all tests pass.
- Manually tested endpoints using curl/Insomnia.
- Verified linting and type checking with `pnpm check`.
- Fixed initial test failures related to Hono error response format (text vs JSON) and timestamp comparisons. 